### PR TITLE
Update Adafruit_ST7796S_kbv.cpp

### DIFF
--- a/Adafruit_ST7796S_kbv.cpp
+++ b/Adafruit_ST7796S_kbv.cpp
@@ -24,9 +24,13 @@
 
 #include "Adafruit_ST7796S_kbv.h"
 #ifndef ARDUINO_STM32_FEATHER
-#include "pins_arduino.h"
-#ifndef RASPI
+#if defined(__has_include)
+#if __has_include("wiring_private.h")
 #include "wiring_private.h"
+#endif  // __has_include("wiring_private.h")
+#else  //defined(__has_include)
+#include "wiring_private.h"
+#endif  //defined(__has_include)
 #endif
 #endif
 #include <limits.h>


### PR DESCRIPTION
Added a conditional where if a user does not have the "wiring_private.h" file then it will be ignored, but if a core of a user does have it, then it will be used. I added this because certain cores of Microcontrollers do not offer this header file such as an Arduino Uno R4 Wifi, And certain Nano controllers as well.